### PR TITLE
Remove useless slice comparison

### DIFF
--- a/executor/message.go
+++ b/executor/message.go
@@ -68,11 +68,7 @@ type errorList struct {
 }
 
 func (el *errorList) addError(err error) {
-	if el.errors == nil {
-		el.errors = []error{err}
-	} else {
-		el.errors = append(el.errors, err)
-	}
+	el.errors = append(el.errors, err)
 }
 
 // deliverMessage recursively visits the source and all nodes and delivers the message if the node accepts this message type.

--- a/fbcontext/fbcontext.go
+++ b/fbcontext/fbcontext.go
@@ -89,9 +89,6 @@ func (c *ContextAware) Subscribe(messageTypes []string) {
 // AcceptsMessage is used when delivering messages to determine if a Source/Node requests delivery of messages with a given
 // messageType.
 func (c *ContextAware) AcceptsMessage(messageType string) bool {
-	if c.messageTypes == nil {
-		return false
-	}
 	for _, t := range c.messageTypes {
 		if messageType == t {
 			return true


### PR DESCRIPTION
Most cases in Go, we don't need to compare slice with nil.
We can just use its zero value usefully.
And actually `append` and `range` work well with nil slice.

This change might depend on this project's preferences.
But, IMHO it is more go-ish.
