### PR TITLE
Multi-Topic Kafka Producer

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -100,7 +100,7 @@ func registerTestNodeTypes() {
 
 	node.GetRegistry().RegisterNodeType("kafkaproducer", func() node.Node {
 		return &kafkaproducer.KafkaProducer{}
-	}, reflect.TypeOf(([]byte)(nil)), nil)
+	}, reflect.TypeOf((*firebolt.ProduceRequest)(nil)).Elem(), nil)
 
 	node.GetRegistry().RegisterNodeType("errorkafkaproducer", func() node.Node {
 		return &kafkaproducer.ErrorProducer{}

--- a/executor/noderegistrar.go
+++ b/executor/noderegistrar.go
@@ -27,7 +27,7 @@ func RegisterBuiltinNodeTypes() {
 
 	node.GetRegistry().RegisterNodeType("kafkaproducer", func() node.Node {
 		return &kafkaproducer.KafkaProducer{}
-	}, reflect.TypeOf(([]byte)(nil)), nil)
+	}, reflect.TypeOf(kafkaproducer.ProduceRequest{}), nil)
 
 	node.GetRegistry().RegisterNodeType("errorkafkaproducer", func() node.Node {
 		return &kafkaproducer.ErrorProducer{}

--- a/executor/noderegistrar.go
+++ b/executor/noderegistrar.go
@@ -27,7 +27,7 @@ func RegisterBuiltinNodeTypes() {
 
 	node.GetRegistry().RegisterNodeType("kafkaproducer", func() node.Node {
 		return &kafkaproducer.KafkaProducer{}
-	}, reflect.TypeOf(kafkaproducer.ProduceRequest{}), nil)
+	}, reflect.TypeOf((*firebolt.ProduceRequest)(nil)).Elem(), nil)
 
 	node.GetRegistry().RegisterNodeType("errorkafkaproducer", func() node.Node {
 		return &kafkaproducer.ErrorProducer{}

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/tidwall/gjson v1.2.1 // indirect
 	github.com/tidwall/match v1.0.1 // indirect
 	github.com/tidwall/pretty v0.0.0-20180105212114-65a9db5fad51 // indirect
-	golang.org/x/sys v0.0.0-20200124204421-9fbb57f87de9 // indirect
+	golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5 // indirect
 	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/yaml.v2 v2.2.8

--- a/go.sum
+++ b/go.sum
@@ -177,8 +177,8 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894 h1:Cz4ceDQGXuKRnVBDTS23GTn/pU5OE2C0WrNTOYK1Uuc=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190801041406-cbf593c0f2f3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200124204421-9fbb57f87de9 h1:1/DFK4b7JH8DmkqhUk48onnSfrPzImPoVxuomtbT2nk=
-golang.org/x/sys v0.0.0-20200124204421-9fbb57f87de9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5 h1:LfCXLvNmTYH9kEmVgqbnsWfruoXZIrh4YBgqVHtDvw0=
+golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4 h1:SvFZT6jyqRaOeXpc5h/JSfZenJ2O330aBsf7JfSUXmQ=

--- a/internal/testnodetypes.go
+++ b/internal/testnodetypes.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/digitalocean/firebolt/node/kafkaproducer"
+
 	"github.com/digitalocean/firebolt/node/elasticsearch"
 
 	log "github.com/sirupsen/logrus"
@@ -70,7 +72,7 @@ func RegisterTestNodeTypes() {
 
 	node.GetRegistry().RegisterNodeType("stringtobytesnode", func() node.Node {
 		return &StringToBytesNode{}
-	}, reflect.TypeOf(""), reflect.TypeOf(([]byte)(nil)))
+	}, reflect.TypeOf(""), reflect.TypeOf(kafkaproducer.ProduceRequest{}))
 
 	node.GetRegistry().RegisterNodeType("asyncfilternode", func() node.Node {
 		return &AsyncFilterNode{}
@@ -298,7 +300,11 @@ func (s *StringToBytesNode) Process(event *firebolt.Event) (*firebolt.Event, err
 	}
 
 	bytes := []byte(str)
-	return event.WithPayload(bytes), nil
+	produceRequest := kafkaproducer.ProduceRequest{
+		Message: bytes,
+	}
+
+	return event.WithPayload(produceRequest), nil
 }
 
 // Shutdown provides an opportunity for the Node to clean up resources on shutdown

--- a/inttest/integration_test.go
+++ b/inttest/integration_test.go
@@ -226,23 +226,23 @@ func produceTestData(count int) {
 			if i%30 == 0 {
 				// 3% of records will be errors: this one gets zero first so (0, 30, 60, 90) == 4
 				kp.Process(&firebolt.Event{
-					Payload: kafkaproducer.ProduceRequest{
-						Message: []byte("error time"),
+					Payload: &firebolt.SimpleProduceRequest{
+						MessageBytes: []byte("error time"),
 					},
 				})
 			} else {
 				// 7% of records will be filtered (10, 20, 40, 50, 70, 80) == 6
 				kp.Process(&firebolt.Event{
-					Payload: kafkaproducer.ProduceRequest{
-						Message: []byte("filter me"),
+					Payload: &firebolt.SimpleProduceRequest{
+						MessageBytes: []byte("filter me"),
 					},
 				})
 			}
 		} else {
 			// 90% of records will be successful () == 90
 			kp.Process(&firebolt.Event{
-				Payload: kafkaproducer.ProduceRequest{
-					Message: []byte("<191>2006-01-02T15:04:05.999999-07:00 host.example.org test: @cee:{\"a\":\"b\"}\n"),
+				Payload: &firebolt.SimpleProduceRequest{
+					MessageBytes: []byte("<191>2006-01-02T15:04:05.999999-07:00 host.example.org test: @cee:{\"a\":\"b\"}\n"),
 				},
 			})
 		}

--- a/inttest/integration_test.go
+++ b/inttest/integration_test.go
@@ -226,18 +226,24 @@ func produceTestData(count int) {
 			if i%30 == 0 {
 				// 3% of records will be errors: this one gets zero first so (0, 30, 60, 90) == 4
 				kp.Process(&firebolt.Event{
-					Payload: []byte("error time"),
+					Payload: kafkaproducer.ProduceRequest{
+						Message: []byte("error time"),
+					},
 				})
 			} else {
 				// 7% of records will be filtered (10, 20, 40, 50, 70, 80) == 6
 				kp.Process(&firebolt.Event{
-					Payload: []byte("filter me"),
+					Payload: kafkaproducer.ProduceRequest{
+						Message: []byte("filter me"),
+					},
 				})
 			}
 		} else {
 			// 90% of records will be successful () == 90
 			kp.Process(&firebolt.Event{
-				Payload: []byte("<191>2006-01-02T15:04:05.999999-07:00 host.example.org test: @cee:{\"a\":\"b\"}\n"),
+				Payload: kafkaproducer.ProduceRequest{
+					Message: []byte("<191>2006-01-02T15:04:05.999999-07:00 host.example.org test: @cee:{\"a\":\"b\"}\n"),
+				},
 			})
 		}
 	}

--- a/inttest/testconfig-withRecovery.yaml
+++ b/inttest/testconfig-withRecovery.yaml
@@ -33,7 +33,7 @@ nodes:
               brokers: localhost:9092
               topic: firebolt-inttest-err
         children:
-          - name: stringtobytesnode
+          - name: stringtoproducerequestnode
             children:
               - name: kafkaproducer
                 workers: 2

--- a/inttest/testconfig.yaml
+++ b/inttest/testconfig.yaml
@@ -25,7 +25,7 @@ nodes:
               brokers: localhost:9092
               topic: firebolt-inttest-err
         children:
-          - name: stringtobytesnode
+          - name: stringtoproducerequestnode
             children:
               - name: kafkaproducer
                 workers: 2
@@ -42,7 +42,7 @@ nodes:
         workers: 1
         buffersize: 1
         children:
-          - name: stringtobytesnode
+          - name: stringtoproducerequestnode
             id: asyncstringtobytesnode
             children:
               - name: kafkaproducer

--- a/node/kafkaconsumer/kafkaconsumer_int_test.go
+++ b/node/kafkaconsumer/kafkaconsumer_int_test.go
@@ -36,7 +36,10 @@ func TestKafkaConsumer(t *testing.T) {
 	// produce 1000 records
 	for i := 0; i < 1000; i++ {
 		kp.Process(&firebolt.Event{
-			Payload: []byte(fmt.Sprintf("record number %d", i)),
+			Payload: kafkaproducer.ProduceRequest{
+				Topic:   topicName,
+				Message: []byte(fmt.Sprintf("record number %d", i)),
+			},
 			Created: time.Now(),
 		})
 	}
@@ -73,7 +76,9 @@ func TestKafkaConsumer(t *testing.T) {
 	// produce 1000 records
 	for i := 0; i < 1000; i++ {
 		kp.Process(&firebolt.Event{
-			Payload: []byte(fmt.Sprintf("record number %d", i)),
+			Payload: kafkaproducer.ProduceRequest{
+				Message: []byte(fmt.Sprintf("record number %d", i)),
+			},
 			Created: time.Now(),
 		})
 	}

--- a/node/kafkaconsumer/kafkaconsumer_int_test.go
+++ b/node/kafkaconsumer/kafkaconsumer_int_test.go
@@ -36,9 +36,9 @@ func TestKafkaConsumer(t *testing.T) {
 	// produce 1000 records
 	for i := 0; i < 1000; i++ {
 		kp.Process(&firebolt.Event{
-			Payload: kafkaproducer.ProduceRequest{
-				Topic:   topicName,
-				Message: []byte(fmt.Sprintf("record number %d", i)),
+			Payload: &firebolt.SimpleProduceRequest{
+				TargetTopic:  topicName,
+				MessageBytes: []byte(fmt.Sprintf("record number %d", i)),
 			},
 			Created: time.Now(),
 		})
@@ -76,8 +76,8 @@ func TestKafkaConsumer(t *testing.T) {
 	// produce 1000 records
 	for i := 0; i < 1000; i++ {
 		kp.Process(&firebolt.Event{
-			Payload: kafkaproducer.ProduceRequest{
-				Message: []byte(fmt.Sprintf("record number %d", i)),
+			Payload: &firebolt.SimpleProduceRequest{
+				MessageBytes: []byte(fmt.Sprintf("record number %d", i)),
 			},
 			Created: time.Now(),
 		})

--- a/node/kafkaconsumer/recoveryconsumer_int_test.go
+++ b/node/kafkaconsumer/recoveryconsumer_int_test.go
@@ -313,7 +313,9 @@ func produceTestRecords(topicName string, numRecords int, t *testing.T) {
 	assert.Nil(t, err)
 	for i := 0; i < numRecords; i++ {
 		kp.Process(&firebolt.Event{
-			Payload: []byte(fmt.Sprintf("record number %d", i)),
+			Payload: kafkaproducer.ProduceRequest{
+				Message: []byte(fmt.Sprintf("record number %d", i)),
+			},
 			Created: time.Now(),
 		})
 	}

--- a/node/kafkaconsumer/recoveryconsumer_int_test.go
+++ b/node/kafkaconsumer/recoveryconsumer_int_test.go
@@ -313,8 +313,8 @@ func produceTestRecords(topicName string, numRecords int, t *testing.T) {
 	assert.Nil(t, err)
 	for i := 0; i < numRecords; i++ {
 		kp.Process(&firebolt.Event{
-			Payload: kafkaproducer.ProduceRequest{
-				Message: []byte(fmt.Sprintf("record number %d", i)),
+			Payload: &firebolt.SimpleProduceRequest{
+				MessageBytes: []byte(fmt.Sprintf("record number %d", i)),
 			},
 			Created: time.Now(),
 		})

--- a/node/kafkaproducer/errorproducer.go
+++ b/node/kafkaproducer/errorproducer.go
@@ -32,8 +32,8 @@ func (ep *ErrorProducer) Process(event *firebolt.Event) (*firebolt.Event, error)
 	}
 
 	return ep.KafkaProducer.Process(&firebolt.Event{
-		Payload: ProduceRequest{
-			Message: errBytes,
+		Payload: &firebolt.SimpleProduceRequest{
+			MessageBytes: errBytes,
 		},
 		Created: event.Created,
 	})

--- a/node/kafkaproducer/errorproducer.go
+++ b/node/kafkaproducer/errorproducer.go
@@ -32,7 +32,9 @@ func (ep *ErrorProducer) Process(event *firebolt.Event) (*firebolt.Event, error)
 	}
 
 	return ep.KafkaProducer.Process(&firebolt.Event{
-		Payload: errBytes,
+		Payload: ProduceRequest{
+			Message: errBytes,
+		},
 		Created: event.Created,
 	})
 }

--- a/node/kafkaproducer/kafkaproducer_test.go
+++ b/node/kafkaproducer/kafkaproducer_test.go
@@ -60,8 +60,8 @@ func TestKafkaProducer(t *testing.T) {
 	assert.NotNil(t, kp.stopChan)
 
 	result, err := kp.Process(&firebolt.Event{
-		Payload: ProduceRequest{
-			Message: []byte("<191>2006-01-02T15:04:05.999999-07:00 host.example.org test: @cee:{\"a\":\"b\"}\n"),
+		Payload: &firebolt.SimpleProduceRequest{
+			MessageBytes: []byte("<191>2006-01-02T15:04:05.999999-07:00 host.example.org test: @cee:{\"a\":\"b\"}\n"),
 		},
 	})
 	assert.Nil(t, err)

--- a/node/kafkaproducer/kafkaproducer_test.go
+++ b/node/kafkaproducer/kafkaproducer_test.go
@@ -39,25 +39,33 @@ func TestSetupInvalidConfig(t *testing.T) {
 }
 
 func TestKafkaProducer(t *testing.T) {
-	// without infrastructure set up for an integration test, best we can do is ensuring that msg makes it to the producer ch
+	// without infrastructure set up for an integration test, best we can do is ensuring that msg makes it to the producer
 	kp := &KafkaProducer{}
 	config := createValidConfig()
-
 	kp.Setup(config)
+
+	// prepare a mock for the actual producer
+	mockProducer := &MockMessageProducer{}
+	kp.producer = mockProducer
+	produceCh := make(chan *kafka.Message, 1000)
+	mockProducer.On("ProduceChannel").Return(produceCh)
+	mockProducer.On("Flush", 5000).Return(0)
+	mockProducer.On("Events").Return(make(chan kafka.Event))
+	mockProducer.On("Close").Return()
+
 	assert.NotNil(t, kp.producer)
 	assert.Equal(t, "testtopic", kp.topic)
 	assert.NotNil(t, kp.stopChan)
 
 	result, err := kp.Process(&firebolt.Event{
-		Payload: []byte("<191>2006-01-02T15:04:05.999999-07:00 host.example.org test: @cee:{\"a\":\"b\"}\n"),
+		Payload: ProduceRequest{
+			Message: []byte("<191>2006-01-02T15:04:05.999999-07:00 host.example.org test: @cee:{\"a\":\"b\"}\n"),
+		},
 	})
 	assert.Nil(t, err)
 	assert.Nil(t, result) // kafkaproducer is a sink node, no data is passed to children
-	//assert.Equal(t, 1, len(kp.producer.ProduceChannel()))
+	assert.Equal(t, 1, len(kp.producer.ProduceChannel()))
 
 	err = kp.Shutdown()
 	assert.Nil(t, err)
-	assert.Panics(t, func() {
-		kp.producer.ProduceChannel() <- &kafka.Message{} // confirm that the channel is closed, shutdown was successful
-	})
 }

--- a/node/kafkaproducer/kafkaproducer_test.go
+++ b/node/kafkaproducer/kafkaproducer_test.go
@@ -1,3 +1,5 @@
+// +build !race
+
 package kafkaproducer
 
 import (

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -33,7 +33,7 @@ func registerTestNodeTypes() {
 
 	node.GetRegistry().RegisterNodeType("kafkaproducer", func() node.Node {
 		return &kafkaproducer.KafkaProducer{}
-	}, reflect.TypeOf(([]byte)(nil)), nil)
+	}, reflect.TypeOf((*firebolt.ProduceRequest)(nil)).Elem(), nil)
 
 	node.GetRegistry().RegisterNodeType("errorkafkaproducer", func() node.Node {
 		return &kafkaproducer.ErrorProducer{}
@@ -42,11 +42,11 @@ func registerTestNodeTypes() {
 	// test types
 	node.GetRegistry().RegisterNodeType("filternode", func() node.Node {
 		return &FilterNode{}
-	}, reflect.TypeOf(""), reflect.TypeOf(([]byte)(nil)))
+	}, reflect.TypeOf(""), reflect.TypeOf((*firebolt.ProduceRequest)(nil)).Elem())
 
 	node.GetRegistry().RegisterNodeType("asyncfilternode", func() node.Node {
 		return &AsyncFilterNode{}
-	}, reflect.TypeOf(""), reflect.TypeOf(([]byte)(nil)))
+	}, reflect.TypeOf(""), reflect.TypeOf((*firebolt.ProduceRequest)(nil)).Elem())
 }
 
 func TestInitContext(t *testing.T) {
@@ -274,7 +274,7 @@ func (f *FilterNode) Process(event *firebolt.Event) (*firebolt.Event, error) {
 	}
 	if !strings.HasPrefix(str, "filter") {
 		return &firebolt.Event{
-			Payload: str,
+			Payload: &firebolt.SimpleProduceRequest{MessageBytes: []byte(str)},
 			Created: event.Created,
 		}, nil
 	}
@@ -312,7 +312,7 @@ func (a *AsyncFilterNode) ProcessAsync(event *firebolt.AsyncEvent) {
 	if !strings.HasPrefix(str, "asyncfilter") {
 		event.ReturnEvent(&firebolt.AsyncEvent{
 			Event: &firebolt.Event{
-				Payload: str,
+				Payload: &firebolt.SimpleProduceRequest{MessageBytes: []byte(str)},
 				Created: event.Created,
 			},
 		})

--- a/node/registry_test.go
+++ b/node/registry_test.go
@@ -19,7 +19,7 @@ func registerNodeTypes() {
 
 	GetRegistry().RegisterNodeType("kafkaproducer", func() Node {
 		return &kafkaproducer.KafkaProducer{}
-	}, reflect.TypeOf(([]byte)(nil)), nil)
+	}, reflect.TypeOf((*firebolt.ProduceRequest)(nil)).Elem(), nil)
 
 	GetRegistry().RegisterNodeType("errorkafkaproducer", func() Node {
 		return &kafkaproducer.ErrorProducer{}

--- a/types.go
+++ b/types.go
@@ -1,0 +1,24 @@
+package firebolt
+
+// ProduceRequest is a request to produce a single message to a topic in a messaging system (AMQP, Kafka, ZMQ, etc).
+type ProduceRequest interface {
+	Topic() string
+	Message() []byte
+}
+
+// SimpleProduceRequest is a default implementation of ProduceRequest that can be used in simple cases to request that
+// a message be produced.
+type SimpleProduceRequest struct {
+	TargetTopic  string
+	MessageBytes []byte
+}
+
+// Topic returns the target topic in the destination messaging system to which this message should be sent.
+func (s *SimpleProduceRequest) Topic() string {
+	return s.TargetTopic
+}
+
+// Message returns the raw message bytes.
+func (s *SimpleProduceRequest) Message() []byte {
+	return s.MessageBytes
+}


### PR DESCRIPTION
Today, the kafkaproducer's `topic` config value sets the only topic that a producer will use.   If a node wishes to send messages to a variety of topics it cannot do so without resorting to awkward workarounds like multiple nodes that each select messages for delivery to a single target topic.

This is a breaking change for users of `kafkaproducer` today.   Where it previously expected to receive payloads of `[]byte`, it now requires a new struct that implements interface `firebolt.ProduceRequest`.  In this interface is the `Message()` (aka payload) which is still a byte array and an optional `Topic()` value which, when returning a nonzero value, overrides the default topic target configured on the `kafkaproducer`.

A trivial implementation `firebolt.SimpleProduceRequest` is provided and used internally, e.g. in `errorproducer`.