### PR TITLE
Remove messaging panic, fix flaky integration test

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/tidwall/gjson v1.2.1 // indirect
 	github.com/tidwall/match v1.0.1 // indirect
 	github.com/tidwall/pretty v0.0.0-20180105212114-65a9db5fad51 // indirect
-	golang.org/x/sys v0.0.0-20200212091648-12a6c2dcc1e4 // indirect
+	golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527 // indirect
 	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/yaml.v2 v2.2.8

--- a/go.sum
+++ b/go.sum
@@ -177,8 +177,8 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894 h1:Cz4ceDQGXuKRnVBDTS23GTn/pU5OE2C0WrNTOYK1Uuc=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190801041406-cbf593c0f2f3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200212091648-12a6c2dcc1e4 h1:sfkvUWPNGwSV+8/fNqctR5lS2AqCSqYwXdrjCxp/dXo=
-golang.org/x/sys v0.0.0-20200212091648-12a6c2dcc1e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527 h1:uYVVQ9WP/Ds2ROhcaGPeIdVq0RIXVLwsHlnvJ+cT1So=
+golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4 h1:SvFZT6jyqRaOeXpc5h/JSfZenJ2O330aBsf7JfSUXmQ=

--- a/message/message.go
+++ b/message/message.go
@@ -58,7 +58,7 @@ func ShutdownKafkaSender() {
 // GetSender returns the singleton sender
 func GetSender() Sender {
 	if senderSingleton == nil {
-		panic("message: illegal attempt to access messagesender before initialization")
+		log.Error("message: illegal attempt to access messagesender before initialization")
 	}
 	return senderSingleton
 }

--- a/node/elasticsearch/elasticsearch_int_test.go
+++ b/node/elasticsearch/elasticsearch_int_test.go
@@ -29,6 +29,7 @@ func TestElasticsearchNode(t *testing.T) {
 
 	// create an index
 	testutil.WaitForPort(t, 9200)                       // wait for ES to be up
+	time.Sleep(time.Second)                             // this test is slightly flaky without a small sleep after the listener is up
 	err := testutil.CreateElasticsearchIndex(indexName) // create the ES target index
 	assert.NoError(t, err)
 


### PR DESCRIPTION
The `panic()` here was a bad idea.   In fact, using singleton at all was a bad idea.    For now, remove the panic to make it possible to write unit tests.

The ES integration test was failing with an `EOF` error intermittently.   Add a small delay so that it succeeds consistently.