### PR TITLE
Support configurable bucket ranges for bulk_process_time Histogram

### DIFF
--- a/docs/node-elasticsearch.md
+++ b/docs/node-elasticsearch.md
@@ -11,26 +11,29 @@ The `elasticsearch` node indexes documents to an Elasticsearch cluster.   Its pa
 
 The IndexRequest type contains four fields:
 
-Field                   | Required | Default | Description              
-------------------------|:--------:|---------|--------------
-Index                   |  *       |         | Destination index name in Elasticsearch.
-MappingType             |          |         | In ES 7.x+, omit MappingType and ES will default to `_doc`.  In ES 6.x-, specify your mapping type. 
-DocID                   |          |         | Provide a document ID to index this document under, or leave nil and ES will assign an ID.
-Doc                     |  *       |         | The document to index.  This should be a struct that is marshallable to JSON.
+| Field       | Required | Default | Description                                                                                         |
+|-------------|:--------:|---------|-----------------------------------------------------------------------------------------------------|
+| Index       |    *     |         | Destination index name in Elasticsearch.                                                            |
+| MappingType |          |         | In ES 7.x+, omit MappingType and ES will default to `_doc`.  In ES 6.x-, specify your mapping type. |
+| DocID       |          |         | Provide a document ID to index this document under, or leave nil and ES will assign an ID.          |
+| Doc         |    *     |         | The document to index.  This should be a struct that is marshallable to JSON.                       |
 
 Internally, `elasticsearch` uses the `BulkService` in the `olivere/elastic` client.
 
 ## Configuration
 
-Param                     | Required | Default | Description              
---------------------------|:--------:|---------|--------------
-elastic-addr              |  *       |         | Comma-separated list of Elasticsearch client nodes.
-elastic-username          |          |         | Username used in http/basic authentication.
-elastic-password          |          |         | Password used in http/basic authentication.
-batch-size                |          | 100     | Wait until this many documents are collected and send them as a single batch.
-batch-max-wait-ms         |          | 1000    | Max time, in ms, to wait for `batch-size` documents to be ready before sending a smaller batch.
-bulk-index-timeout-ms     |          | 5000    | Timeout passed to Elasticsearch along with the bulk index request.
-reconnect-batch-count     |          | 10000   | Reestablish connections to ES after this many batches.  Useful to ensure that load remains distributed among ES client nodes as they are created or fail.
-bulk-index-max-retries    |          | 3       | Number of times to retry indexing errors.   Mapping errors / field type conflicts are not retryable.
-bulk-index-timeout-seconds|          | 20      | Forcibly cancel individual bulk indexing operations after this time.
-index-workers             |          | 1       | Number of goroutine workers to use to process batch indexing operations against Elasticsearch.
+| Param                      | Required | Default                          | Description                                                                                                                                               |
+|----------------------------|:--------:|----------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------|
+| elastic-addr               |    *     |                                  | Comma-separated list of Elasticsearch client nodes.                                                                                                       |
+| elastic-username           |          |                                  | Username used in http/basic authentication.                                                                                                               |
+| elastic-password           |          |                                  | Password used in http/basic authentication.                                                                                                               |
+| batch-size                 |          | 100                              | Wait until this many documents are collected and send them as a single batch.                                                                             |
+| batch-max-wait-ms          |          | 1000                             | Max time, in ms, to wait for `batch-size` documents to be ready before sending a smaller batch.                                                           |
+| bulk-index-timeout-ms      |          | 5000                             | Timeout passed to Elasticsearch along with the bulk index request.                                                                                        |
+| reconnect-batch-count      |          | 10000                            | Reestablish connections to ES after this many batches.  Useful to ensure that load remains distributed among ES client nodes as they are created or fail. |
+| bulk-index-max-retries     |          | 3                                | Number of times to retry indexing errors.   Mapping errors / field type conflicts are not retryable.                                                      |
+| bulk-index-timeout-seconds |          | 20                               | Forcibly cancel individual bulk indexing operations after this time.                                                                                      |
+| index-workers              |          | 1                                | Number of goroutine workers to use to process batch indexing operations against Elasticsearch.                                                            |
+| histogram-min-bucket-sec   |          | 0.01                             | Smallest bucket describing observed Elasticsearch client indexing time.                                                                                   |
+| histogram-max-bucket-sec   |          | 2 * (bulk-index-timeout-ms/1000) | Maximum bucket describing observed Elasticsearch client indexing time.                                                                                    |
+| histogram-bucket-count     |          | 8                                | Number of buckets to generate between min and max histogram bucket seconds.                                                                               |

--- a/helpers.go
+++ b/helpers.go
@@ -60,3 +60,35 @@ func (c Nodeconfig) StringConfigRequired(name string) (string, error) {
 	}
 	return userValue, nil
 }
+
+// Float64Config validates and fetches the flaot-typed optional config value specified by 'name', using the 'defaultValue' if
+// no value was provided in the configuration. The default float64 (if used) is formatted following platform-and-golang
+// default precision and width (%f formatting).
+func (c Nodeconfig) Float64Config(name string, defaultValue float64, minValue float64, maxValue float64) (float64, error) {
+	// set the default value, if not provided
+	_, ok := c[name]
+	if !ok {
+		c[name] = fmt.Sprintf("%f", defaultValue)
+	}
+
+	return c.Float64ConfigRequired(name, minValue, maxValue)
+}
+
+// Float64ConfigRequired validates and fetches the float64-typed required config value specified by 'name', returning an error
+// if no value was provided in the configuration.
+func (c Nodeconfig) Float64ConfigRequired(name string, minValue, maxValue float64) (float64, error) {
+	userValue, ok := c[name]
+	if !ok {
+		return 0, fmt.Errorf("missing config value [%s]", name)
+	}
+
+	f64Value, err := strconv.ParseFloat(userValue, 64)
+	if err != nil {
+		return 0, fmt.Errorf("expected float64 value for config [%s]", name)
+	}
+
+	if f64Value > maxValue || f64Value < minValue {
+		return 0, fmt.Errorf("config value [%s] requires value between [%f] and [%f]", name, minValue, maxValue)
+	}
+	return f64Value, nil
+}

--- a/node/elasticsearch/connectionfactory_int_test.go
+++ b/node/elasticsearch/connectionfactory_int_test.go
@@ -17,7 +17,7 @@ func TestReconnect(t *testing.T) {
 	metrics.Init("elasticsearch")
 
 	metrics := &Metrics{}
-	metrics.RegisterElasticIndexMetrics()
+	metrics.RegisterElasticIndexMetrics(0.1, 20.0, 8)
 
 	cf := newEsBulkServiceFactory(context.TODO(), "http://localhost:9200", "", "", 3, 10000, metrics)
 

--- a/node/elasticsearch/elasticsearch.go
+++ b/node/elasticsearch/elasticsearch.go
@@ -82,9 +82,24 @@ func (i *Elasticsearch) Setup(cfgMap map[string]string) error {
 		return err
 	}
 
+	bulkProcessHistogramMin, err := config.Float64Config("histogram-min-bucket-sec", 0.01, 0.01, math.MaxFloat64)
+	if err != nil {
+		return err
+	}
+
+	bulkProcessHistogramMax, err := config.Float64Config("histogram-max-bucket-sec", float64(2*(bulkIndexTimeoutMs/1000)), 0.01, math.MaxFloat64)
+	if err != nil {
+		return err
+	}
+
+	bulkProcessingHistogramBuckets, err := config.IntConfig("histogram-bucket-count", 8, 1, math.MaxInt)
+	if err != nil {
+		return err
+	}
+
 	// initialize metrics
 	metrics := &Metrics{}
-	metrics.RegisterElasticIndexMetrics()
+	metrics.RegisterElasticIndexMetrics(bulkProcessHistogramMin, bulkProcessHistogramMax, bulkProcessingHistogramBuckets)
 
 	// service factory; in tests it must be prepopulated with a mock
 	if i.serviceFactory == nil {

--- a/node/elasticsearch/metrics_test.go
+++ b/node/elasticsearch/metrics_test.go
@@ -15,18 +15,8 @@ func Test_generateElasticsearchProcessTimeBuckets(t *testing.T) {
 	tests := []struct {
 		name      string
 		args      args
-		want      []float64
-		wantPanic bool
+		wantCount int
 	}{
-		{
-			name: "panics upon bad input",
-			args: args{
-				min:   -0.01,
-				max:   0.00,
-				count: 0,
-			},
-			wantPanic: true,
-		},
 		{
 			name: "creates expected number of default buckets",
 			args: args{
@@ -34,19 +24,12 @@ func Test_generateElasticsearchProcessTimeBuckets(t *testing.T) {
 				max:   10,
 				count: 8,
 			},
-			want:      []float64{0.01, 0.026826957952797256, 0.07196856730011518, 0.19306977288832497, 0.5179474679231209, 1.3894954943731366, 3.7275937203149367, 9.999999999999991},
-			wantPanic: false,
+			wantCount: 8,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.wantPanic {
-				assert.Panics(t, func() {
-					generateElasticsearchProcessTimeBuckets(tt.args.min, tt.args.max, tt.args.count)
-				}, nil)
-				return
-			}
-			assert.Equalf(t, tt.want, generateElasticsearchProcessTimeBuckets(tt.args.min, tt.args.max, tt.args.count), "generateElasticsearchProcessTimeBuckets(%v, %v, %v)", tt.args.min, tt.args.max, tt.args.count)
+			assert.Equalf(t, tt.wantCount, len(generateElasticsearchProcessTimeBuckets(tt.args.min, tt.args.max, tt.args.count)), "generateElasticsearchProcessTimeBuckets(%v, %v, %v)", tt.args.min, tt.args.max, tt.args.count)
 		})
 	}
 }

--- a/node/elasticsearch/metrics_test.go
+++ b/node/elasticsearch/metrics_test.go
@@ -1,0 +1,52 @@
+package elasticsearch
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_generateElasticsearchProcessTimeBuckets(t *testing.T) {
+	type args struct {
+		min   float64
+		max   float64
+		count int
+	}
+	tests := []struct {
+		name      string
+		args      args
+		want      []float64
+		wantPanic bool
+	}{
+		{
+			name: "panics upon bad input",
+			args: args{
+				min:   -0.01,
+				max:   0.00,
+				count: 0,
+			},
+			wantPanic: true,
+		},
+		{
+			name: "creates expected number of default buckets",
+			args: args{
+				min:   0.01,
+				max:   10,
+				count: 8,
+			},
+			want:      []float64{0.01, 0.026826957952797256, 0.07196856730011518, 0.19306977288832497, 0.5179474679231209, 1.3894954943731366, 3.7275937203149367, 9.999999999999991},
+			wantPanic: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.wantPanic {
+				assert.Panics(t, func() {
+					generateElasticsearchProcessTimeBuckets(tt.args.min, tt.args.max, tt.args.count)
+				}, nil)
+				return
+			}
+			assert.Equalf(t, tt.want, generateElasticsearchProcessTimeBuckets(tt.args.min, tt.args.max, tt.args.count), "generateElasticsearchProcessTimeBuckets(%v, %v, %v)", tt.args.min, tt.args.max, tt.args.count)
+		})
+	}
+}


### PR DESCRIPTION
Greetings,

First time contributor, please let me know if this is an acceptable PR!

To address #45, I am proposing a set of changes which amount to:

- Allow for float64 inputs from Firebolt config
- Add 3x new configuration options on the `elasticsearch` node type, related to Histogram bucket configuration, _min_, _max_, and _count_ (matching the inputs of `prometheus.ExponentialBuckets`/`prometheus.ExponentialBucketsRange`)
- Begin passing in user-supplied options, or what should be safe defaults. For defaults, I opted to match the existing Firebolt choices as closely as possible:
  -  0.01 for a bucket _min_
  - 2 * (bulk-index-timeout-ms / 1000) for a bucket _max_. I'm open to changing this, however it seems appropriate to clamp the maximum this way to reduce the chances of observations being lumped into `+Inf` which is not as helpful when often timeouts are 🤏 just barely (by a few seconds, at most) over bulk-index-timeout-ms
  - 8 buckets

Using the defaults above, and assuming a 5000ms `bulk-index-timeout-ms` in unit testing, this PR results in the following buckets on my machine: `0.01, 0.026826957952797256, 0.07196856730011518, 0.19306977288832497, 0.5179474679231209, 1.3894954943731366, 3.7275937203149367, 9.999999999999991` 