### PR TITLE
fix(testutil/WaitForPort ): conn.Close panic with nil Point

### DIFF
--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -29,11 +29,12 @@ func AwaitCondition(cond util.Condition, period time.Duration, maxWait time.Dura
 // run are ready.d
 func WaitForPort(t *testing.T, port int) error {
 	err := AwaitCondition(func() bool {
-		conn, err := net.Dial("tcp", "localhost:"+strconv.Itoa(port))
-		if err != nil {
+		conn, _ := net.Dial("tcp", "localhost:"+strconv.Itoa(port))
+		if conn != nil {
 			conn.Close()
+			return true
 		}
-		return err != nil
+		return false
 	}, 500*time.Millisecond, 60*time.Second)
 	return err
 }


### PR DESCRIPTION
examples/run.sh has error for it wil panic when run into the code for waiting services to start

![d2d5c41e4dd540b9b5e95e1f26446efc](https://github.com/digitalocean/firebolt/assets/26030229/5af3fd02-c563-4df9-9209-b09e4b8eed0e)

fixed it with the code and now it's ok

![2ee8da95fceb43adaef5d55ed550999c](https://github.com/digitalocean/firebolt/assets/26030229/122fd610-300e-4f64-835f-51442fa10d99)

